### PR TITLE
Add Org wide Github Sponsors for core team

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [clue, WyriHaximus, jsor, cboden]


### PR DESCRIPTION
Added the entire core team, any account that has Github Sponsors active will automatically show up on all repositories