### PR TITLE
Remove jsor and cboden due to Github error message

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [clue, WyriHaximus, jsor, cboden]
+github: [clue, WyriHaximus]


### PR DESCRIPTION
When there are users in the list not enrolled in the Github sponsors program it shows an error instead of ignoring them as we expected

![image](https://user-images.githubusercontent.com/147145/88456032-b9fe3c80-ce7a-11ea-8275-8bfed1e6669c.png)
