### PR TITLE
Add ReactPHP sponsors profile to `FUNDING.yml`

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,5 @@
-github: [clue, WyriHaximus]
+github:
+  - reactphp
+  - clue
+  - WyriHaximus
+open_collective: reactphp


### PR DESCRIPTION
This adds the new ReactPHP sponsors profile to our funding file in order to link to ReactPHP's GitHub and Open Collective sponsor sites.

![grafik](https://user-images.githubusercontent.com/44357440/199488940-a13ab667-f2a4-494a-bffc-dbc8b063d1bd.png)

See https://github.com/sponsors/reactphp and https://opencollective.com/reactphp

Builds on top of #1/#2